### PR TITLE
Colors, Catalog, Enhacements after Backend integration

### DIFF
--- a/lib/core/models/listing.dart
+++ b/lib/core/models/listing.dart
@@ -1,5 +1,5 @@
-/// Model representing a marketplace listing.
-class PostItem {
+/// Core domain model representing a marketplace listing.
+class Listing {
   final String? id;
   final String title;
   final String description;
@@ -14,7 +14,7 @@ class PostItem {
   final String? sellerAvatarUrl;
   final DateTime? createdAt;
 
-  PostItem({
+  Listing({
     this.id,
     required this.title,
     required this.description,
@@ -30,9 +30,9 @@ class PostItem {
     this.createdAt,
   });
 
-  factory PostItem.fromJson(Map<String, dynamic> json) {
+  factory Listing.fromJson(Map<String, dynamic> json) {
     final seller = json['seller'] as Map<String, dynamic>?;
-    return PostItem(
+    return Listing(
       id: json['id'],
       title: json['title'] ?? '',
       description: json['description'] ?? '',

--- a/lib/core/services/api_config.dart
+++ b/lib/core/services/api_config.dart
@@ -1,7 +1,12 @@
+import 'dart:io';
+
 /// Configuración central del API
 class ApiConfig {
-  // TODO: Cambiar a la URL real cuando el backend esté desplegado
-  static const String baseUrl = 'http://localhost:3000';
+  // Cuando el backend esté desplegado, reemplazar con la URL de AWS.
+  static String get baseUrl {
+    if (Platform.isAndroid) return 'http://10.0.2.2:3000';
+    return 'http://localhost:3000';
+  }
   
   // Endpoints disponibles
   static const String homeEndpoint = '/home';

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
 import 'api_config.dart';
 import 'storage_service.dart';
-import '../../features/post/models/post_item.dart';
+import '../models/listing.dart';
 
 /// Servicio central para peticiones HTTP al API
 class ApiService {
@@ -185,7 +186,7 @@ class ApiService {
       );
 
       if (token != null) {
-        request.headers.addAll(ApiConfig.authHeaders(token));
+        request.headers['Authorization'] = 'Bearer $token';
       }
 
       request.fields['title'] = title;
@@ -196,8 +197,14 @@ class ApiService {
       request.fields['condition'] = condition;
 
       for (final image in images) {
+        final ext = image.path.split('.').last.toLowerCase();
+        final subtype = (ext == 'png' || ext == 'gif' || ext == 'webp') ? ext : 'jpeg';
         request.files.add(
-          await http.MultipartFile.fromPath('images', image.path),
+          await http.MultipartFile.fromPath(
+            'images',
+            image.path,
+            contentType: MediaType('image', subtype),
+          ),
         );
       }
 
@@ -211,12 +218,12 @@ class ApiService {
       return false;
     }
   }
-  
+
   /// Fetch the most recent listings for the Home screen.
-  Future<List<PostItem>> getRecentProducts() async {
+  Future<List<Listing>> getRecentProducts() async {
     try {
       final data = await getProducts();
-      return data.map((json) => PostItem.fromJson(json)).toList();
+      return data.map((json) => Listing.fromJson(json)).toList();
     } catch (e) {
       return [];
     }

--- a/lib/features/auth/viewmodels/auth_viewmodel.dart
+++ b/lib/features/auth/viewmodels/auth_viewmodel.dart
@@ -35,22 +35,18 @@ class AuthViewModel extends ChangeNotifier {
         if (response['refresh_token'] != null) {
           await _storageService.saveRefreshToken(response['refresh_token']);
         }
-        
+
         if (response['user'] != null) {
           _user = AuthUser.fromJson(response['user']);
         }
-        
+
         _status = AuthStatus.authenticated;
       } else {
-        // Use the API error message if available, otherwise a generic one
-        _errorMessage = response?['message'] ??
-            'Incorrect email or password. Please check and try again.';
+        _errorMessage = 'Incorrect email or password. Please check and try again.';
         _status = AuthStatus.unauthenticated;
       }
     } catch (e) {
-      // Network or server error — the backend may be unreachable
-      _errorMessage =
-          'Unable to connect to the server. Please check your internet connection and try again.';
+      _errorMessage = 'Unable to connect to the server. Please check your internet connection and try again.';
       _status = AuthStatus.unauthenticated;
     }
     

--- a/lib/features/auth/views/login_view.dart
+++ b/lib/features/auth/views/login_view.dart
@@ -119,13 +119,6 @@ class _LoginViewState extends State<LoginView> {
                         if (value == null || value.trim().isEmpty) {
                           return 'Email is required';
                         }
-                        if (!value.trim().endsWith('@uniandes.edu.co')) {
-                          return 'Must be a @uniandes.edu.co email';
-                        }
-                        final username = value.trim().split('@').first;
-                        if (username.isEmpty) {
-                          return 'Enter your username before @uniandes.edu.co';
-                        }
                         return null;
                       },
                     ),
@@ -165,9 +158,6 @@ class _LoginViewState extends State<LoginView> {
                       validator: (value) {
                         if (value == null || value.isEmpty) {
                           return 'Password is required';
-                        }
-                        if (value.length < 6) {
-                          return 'Password must be at least 6 characters';
                         }
                         return null;
                       },

--- a/lib/features/catalog/viewmodels/catalog_viewmodel.dart
+++ b/lib/features/catalog/viewmodels/catalog_viewmodel.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
+import '../../../core/models/listing.dart';
 import '../../../core/services/api_service.dart';
 import '../../../core/services/location_service.dart';
-import '../../post/models/post_item.dart';
 
 export '../../../core/constants/post_conditions.dart';
 
@@ -17,7 +17,7 @@ class CatalogViewModel extends ChangeNotifier {
   final LocationService _locationService = LocationService();
 
   CatalogStatus _status = CatalogStatus.initial;
-  List<PostItem> _products = [];
+  List<Listing> _products = [];
   String? _errorMessage;
   String _searchQuery = '';
   String? _selectedCategory;
@@ -27,12 +27,12 @@ class CatalogViewModel extends ChangeNotifier {
   // ── Location state ──
   String? _nearestBuilding;
   List<String> _nearbyBuildings = [];
-  List<PostItem> _nearbyProducts = [];
+  List<Listing> _nearbyProducts = [];
   bool _locationLoaded = false;
   bool _isOnCampus = false;
 
   CatalogStatus get status => _status;
-  List<PostItem> get products => List.unmodifiable(_products);
+  List<Listing> get products => List.unmodifiable(_products);
   String? get errorMessage => _errorMessage;
   String get searchQuery => _searchQuery;
   String? get selectedCategory => _selectedCategory;
@@ -41,7 +41,7 @@ class CatalogViewModel extends ChangeNotifier {
 
   String? get nearestBuilding => _nearestBuilding;
   List<String> get nearbyBuildings => List.unmodifiable(_nearbyBuildings);
-  List<PostItem> get nearbyProducts => List.unmodifiable(_nearbyProducts);
+  List<Listing> get nearbyProducts => List.unmodifiable(_nearbyProducts);
   bool get locationLoaded => _locationLoaded;
   bool get isOnCampus => _isOnCampus;
 
@@ -89,7 +89,7 @@ class CatalogViewModel extends ChangeNotifier {
         priceSort: _selectedPriceSort,
       );
 
-      _products = data.map((json) => PostItem.fromJson(json)).toList();
+      _products = data.map((json) => Listing.fromJson(json)).toList();
       _partitionNearbyProducts();
       _status = CatalogStatus.loaded;
     } catch (e) {

--- a/lib/features/catalog/views/catalog_view.dart
+++ b/lib/features/catalog/views/catalog_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../core/constants/post_categories.dart';
-import '../../post/models/post_item.dart';
+import '../../../core/models/listing.dart';
 import '../viewmodels/catalog_viewmodel.dart';
 import 'product_detail_view.dart';
 
@@ -744,7 +744,7 @@ class _FilterButton extends StatelessWidget {
 
 // ── Individual product card ──
 class _ProductCard extends StatelessWidget {
-  final PostItem item;
+  final Listing item;
   final VoidCallback onTap;
 
   const _ProductCard({required this.item, required this.onTap});

--- a/lib/features/catalog/views/product_detail_view.dart
+++ b/lib/features/catalog/views/product_detail_view.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import '../../post/models/post_item.dart';
+import '../../../core/models/listing.dart';
 
-/// Product Detail page matching the Figma design.
 ///
-/// Receives a [PostItem] and displays its full information:
+/// Receives a [Listing] and displays its full information:
 /// hero image, title, price, seller info, description, and action buttons.
 class ProductDetailView extends StatelessWidget {
-  final PostItem item;
+  final Listing item;
 
   const ProductDetailView({super.key, required this.item});
 
@@ -152,19 +151,19 @@ class ProductDetailView extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                sellerName,
-                style: const TextStyle(
-                  fontSize: 12,
-                  color: Color(0xFF96914F),
-                ),
-              ),
               const Text(
                 'Seller Information',
                 style: TextStyle(
                   fontSize: 15,
                   fontWeight: FontWeight.w600,
                   color: Colors.black87,
+                ),
+              ),
+              Text(
+                sellerName,
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: Color(0xFF96914F),
                 ),
               ),
               if (sellerMajor.isNotEmpty)

--- a/lib/features/home/viewmodels/home_viewmodel.dart
+++ b/lib/features/home/viewmodels/home_viewmodel.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import '../../../core/services/api_service.dart';
-import '../../post/models/post_item.dart';
+import '../../../core/models/listing.dart';
 
 enum HomeStatus { initial, loading, loaded, error }
 
@@ -9,11 +9,11 @@ class HomeViewModel extends ChangeNotifier {
   final ApiService _apiService = ApiService();
 
   HomeStatus _status = HomeStatus.initial;
-  List<PostItem> _recentlyAddedItems = [];
+  List<Listing> _recentlyAddedItems = [];
   String? _errorMessage;
 
   HomeStatus get status => _status;
-  List<PostItem> get recentlyAddedItems => List.unmodifiable(_recentlyAddedItems);
+  List<Listing> get recentlyAddedItems => List.unmodifiable(_recentlyAddedItems);
   String? get errorMessage => _errorMessage;
 
   /// Cargar los productos recientes desde /products

--- a/lib/features/home/views/home_view.dart
+++ b/lib/features/home/views/home_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../catalog/views/product_detail_view.dart';
-import '../../post/models/post_item.dart';
+import '../../../core/models/listing.dart';
 import '../viewmodels/home_viewmodel.dart';
 
 /// Vista de Home
@@ -39,7 +39,8 @@ class _HomeViewState extends State<HomeView> {
       body: SafeArea(
         child: Consumer<HomeViewModel>(
           builder: (context, viewModel, child) {
-            if (viewModel.status == HomeStatus.loading) {
+            if (viewModel.status == HomeStatus.loading &&
+                viewModel.recentlyAddedItems.isEmpty) {
               return const Center(child: CircularProgressIndicator());
             }
             
@@ -309,7 +310,7 @@ class _HomeViewState extends State<HomeView> {
     );
   }
   
-  Widget _buildRecentlyAddedItem(PostItem item) {
+  Widget _buildRecentlyAddedItem(Listing item) {
     final imageUrl = item.imageUrls.isNotEmpty ? item.imageUrls.first : '';
     return Container(
       width: 180,

--- a/lib/features/navigation/main_screen.dart
+++ b/lib/features/navigation/main_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../home/views/home_view.dart';
 import '../home/viewmodels/home_viewmodel.dart';
 import '../catalog/views/catalog_view.dart';
+import '../catalog/viewmodels/catalog_viewmodel.dart';
 import '../post/views/post_view.dart';
 import '../favorites/views/favorites_view.dart';
 import '../profile/views/profile_view.dart';
@@ -18,47 +19,46 @@ class MainScreen extends StatefulWidget {
 class _MainScreenState extends State<MainScreen> {
   int _currentIndex = 0;
 
-  final List<Widget> _screens = const [
-    HomeView(),
-    CatalogView(),
-    SizedBox.shrink(), // Post opens as a modal route, not a tab
-    FavoritesView(),
-    ProfileView(),
-  ];
+  void _onTabTap(int index) {
+    if (index == 2) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          fullscreenDialog: true,
+          builder: (_) => const PostView(),
+        ),
+      ).then((_) {
+        if (!mounted) return;
+        context.read<HomeViewModel>().loadHomeData();
+        context.read<CatalogViewModel>().loadProducts();
+      });
+      return;
+    }
+    if (index == 0 && _currentIndex != 0) {
+      context.read<HomeViewModel>().loadHomeData();
+    }
+
+    setState(() {
+      _currentIndex = index;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: IndexedStack(
         index: _currentIndex,
-        children: [
-          ChangeNotifierProvider(
-            create: (_) => HomeViewModel(),
-            child: const HomeView(),
-          ),
-          const CatalogView(),
-          const PostView(),
-          const FavoritesView(),
-          const ProfileView(),
+        children: const [
+          HomeView(),
+          CatalogView(),
+          SizedBox.shrink(),
+          FavoritesView(),
+          ProfileView(),
         ],
       ),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex,
-        onTap: (index) {
-          if (index == 2) {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                fullscreenDialog: true,
-                builder: (_) => const PostView(),
-              ),
-            );
-            return;
-          }
-          setState(() {
-            _currentIndex = index;
-          });
-        },
+        onTap: _onTabTap,
         type: BottomNavigationBarType.fixed,
         selectedItemColor: Colors.black,
         unselectedItemColor: const Color(0xFF99944D),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'core/auth_gate.dart';
 import 'features/auth/viewmodels/auth_viewmodel.dart';
 import 'features/catalog/viewmodels/catalog_viewmodel.dart';
+import 'features/home/viewmodels/home_viewmodel.dart';
 import 'features/post/viewmodels/post_viewmodel.dart';
 
 void main() {
@@ -18,6 +19,7 @@ class MyApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthViewModel()),
+        ChangeNotifierProvider(create: (_) => HomeViewModel()),
         ChangeNotifierProvider(create: (_) => CatalogViewModel()),
         ChangeNotifierProvider(create: (_) => PostViewModel()),
       ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -337,7 +337,7 @@ packages:
     source: hosted
     version: "1.6.0"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   google_fonts: ^8.0.2
   image_picker: ^1.2.1
   geolocator: ^14.0.2
+  http_parser: ^4.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Description of changes:

- Renamed PostItem: Listing and moved it from post/models/ to core/models/listing.dart, since it's a shared domain entity used by home, catalog, and post features 
- Added HomeViewModel to the global MultiProvider in main.dart (previously it was created locally inside MainScreen, preventing cross-tab communication) 
- api_config.dart: baseUrl is now platform-aware: Android uses http://10.0.2.2:3000 (emulator host), iOS/other uses http://localhost:3000 
- login_view.dart: Removed inline validators that revealed sensitive info: email domain requirement (@uniandes.edu.co) and minimum password length, login now only checks that fields are not empty, all other errors show as a generic message below the button 
- main_screen.dart: Added _onTabTap that tries to refresh Home data when switching back to tab 0, and refreshes both Home and Catalog when the Post modal closes 
- Reordered seller section: "Seller Information" label now appears above the seller name and major